### PR TITLE
Ignore changes to final_snapshot_identifier.

### DIFF
--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -90,4 +90,11 @@ resource "aws_db_instance" "main" {
   tags = {
     Name = "v3"
   }
+
+  # Ignore changes to final_snapshot_identifier, which are caused by the
+  # timestamp being regenerated on each run.
+  lifecycle {
+    ignore_changes = [final_snapshot_identifier]
+  }
 }
+


### PR DESCRIPTION
Since this is based on a timestamp, and that timestamp is recreated on
every run, `terraform plan` will always show that the RDS instance
requires and apply run with changes.

This change adds a lifecycle rule to ignore changes to the
final_snapshot_identifier.

When there are other changes to the RDS resource, the
final_snapshot_identifier will be updated, but it "needing" to be
updated will not cause erroneous "things have changed" messages.

Of course there might be a better way to handle this, which as putting
the timestamp in vars, but this has the downside that it would be easy
to create duplicate snapshot identifiers.