### PR TITLE
Add canary to tooling invoker

### DIFF
--- a/terraform/files/bucket_assets.tf
+++ b/terraform/files/bucket_assets.tf
@@ -11,6 +11,17 @@ resource "aws_s3_bucket" "assets" {
     expose_headers  = ["ETag"]
     max_age_seconds = 3000
   }
+  
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
 }
 
 data "aws_iam_policy_document" "bucket_assets_read" {

--- a/terraform/files/bucket_attachments.tf
+++ b/terraform/files/bucket_attachments.tf
@@ -15,6 +15,17 @@ resource "aws_s3_bucket" "attachments" {
     expose_headers  = ["ETag"]
     max_age_seconds = 3000
   }
+  
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
 }
 
 resource "aws_iam_policy" "bucket_attachments_access" {

--- a/terraform/files/bucket_icons.tf
+++ b/terraform/files/bucket_icons.tf
@@ -9,6 +9,18 @@ resource "aws_s3_bucket" "icons" {
     expose_headers  = ["ETag"]
     max_age_seconds = 3000
   }
+
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+
 }
 
 data "aws_iam_policy_document" "bucket_icons_read" {

--- a/terraform/files/bucket_logs.tf
+++ b/terraform/files/bucket_logs.tf
@@ -14,4 +14,15 @@ resource "aws_s3_bucket" "ops_bucket" {
     ]
     type = "CanonicalUser"
   }
+  
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
 }

--- a/terraform/files/bucket_submissions.tf
+++ b/terraform/files/bucket_submissions.tf
@@ -5,6 +5,17 @@ resource "aws_s3_bucket" "submissions" {
   versioning {
     enabled = true
   }
+  
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
 }
 
 # Note: This policy does not have the ability to delete objects

--- a/terraform/files/bucket_tooling_jobs.tf
+++ b/terraform/files/bucket_tooling_jobs.tf
@@ -1,6 +1,17 @@
 resource "aws_s3_bucket" "tooling_jobs" {
   bucket = var.bucket_tooling_jobs_name
   acl    = "private"
+  
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
 }
 
 resource "aws_iam_policy" "bucket_tooling_jobs_write" {

--- a/terraform/files/bucket_uploads.tf
+++ b/terraform/files/bucket_uploads.tf
@@ -20,6 +20,17 @@ resource "aws_s3_bucket" "uploads" {
   #   expose_headers  = ["ETag"]
   #   max_age_seconds = 3000
   # }
+  
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
 }
 
 resource "aws_iam_policy" "bucket_uploads_access" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -222,7 +222,7 @@ module "webservers" {
 
   service_website_cpu    = 1024
   service_website_memory = 2048
-  service_website_count  = 3
+  service_website_count  = 6
 
   service_api_cpu    = 1024
   service_api_memory = 2048
@@ -230,7 +230,7 @@ module "webservers" {
 
   service_anycable_cpu    = 2048
   service_anycable_memory = 4096
-  service_anycable_count  = 3
+  service_anycable_count  = 6
 
   http_port       = local.http_port
   websockets_port = local.websockets_port

--- a/terraform/tooling_invoker/ami.sh
+++ b/terraform/tooling_invoker/ami.sh
@@ -45,6 +45,9 @@ sudo groupadd exercism
 sudo useradd -g exercism -m -s /bin/bash exercism
 sudo loginctl enable-linger exercism
 
+#############################################
+# Allow the canary to shut down the machine #
+#############################################
 sudo su
   echo "exercism ALL=(ALL) NOPASSWD: /sbin/shutdown" > /etc/sudoers.d/shutdown
 exit
@@ -312,9 +315,8 @@ sudo systemctl start exercism-invoker.service
 sudo systemctl start exercism-canary.service
 
 docker logout
-aws ecr get-login-password --region eu-west-2 | docker login -u AWS --password-stdin 591712695352.dkr.ecr.eu-west-2.amazonaws.com
-
-docker pull exercism/ruby-test-runner:production
+aws ecr get-login-password --region eu-west-2 | docker login -u AWS --password-stdin 681735686245.dkr.ecr.eu-west-2.amazonaws.com
+docker pull 681735686245.dkr.ecr.eu-west-2.amazonaws.com/ruby-test-runner:production
 
 #ln -s $CONTAINER_DIR /opt/containers/ruby-test-runner/current
 

--- a/terraform/tooling_invoker/ami.sh
+++ b/terraform/tooling_invoker/ami.sh
@@ -226,9 +226,9 @@ EOM
   systemctl enable exercism-manager.service
 exit
 
-############################
-# Setup Systemd for canary #
-############################
+#####################################
+# Setup Systemd for tooling invoker #
+#####################################
 sudo su -
   cat >/etc/systemd/system/exercism-invoker.service << EOM
 [Unit]

--- a/terraform/tooling_invoker/ami.sh
+++ b/terraform/tooling_invoker/ami.sh
@@ -314,7 +314,7 @@ sudo systemctl start exercism-canary.service
 docker logout
 aws ecr get-login-password --region eu-west-2 | docker login -u AWS --password-stdin 591712695352.dkr.ecr.eu-west-2.amazonaws.com
 
-# docker pull exercism/ruby-test-runner:production
+docker pull exercism/ruby-test-runner:production
 
 #ln -s $CONTAINER_DIR /opt/containers/ruby-test-runner/current
 

--- a/terraform/tooling_invoker/ami.sh
+++ b/terraform/tooling_invoker/ami.sh
@@ -271,7 +271,7 @@ sudo systemctl start exercism-invoker.service
 docker logout
 aws ecr get-login-password --region eu-west-2 | docker login -u AWS --password-stdin 591712695352.dkr.ecr.eu-west-2.amazonaws.com
 
-docker pull exercism/elixir-test-runner:production
+# docker pull exercism/ruby-test-runner:production
 
 #ln -s $CONTAINER_DIR /opt/containers/ruby-test-runner/current
 

--- a/terraform/tooling_invoker/launch_template.tf
+++ b/terraform/tooling_invoker/launch_template.tf
@@ -1,6 +1,6 @@
 resource "aws_launch_template" "main" {
-  image_id                = "ami-03c207961a2d90a8e"
-  instance_type           = "t4g.small"
+  image_id                = "ami-0b8768870a5bbf431"
+  instance_type           = "t3.small"
   key_name                = "iHiD-v3"
   name                    = "Tooling-Invokers"
   tags                    = {}

--- a/terraform/tooling_invoker/launch_template.tf
+++ b/terraform/tooling_invoker/launch_template.tf
@@ -1,6 +1,6 @@
 resource "aws_launch_template" "main" {
   image_id                = "ami-03c207961a2d90a8e"
-  instance_type           = "t3.small"
+  instance_type           = "t4g.small"
   key_name                = "iHiD-v3"
   name                    = "Tooling-Invokers"
   tags                    = {}

--- a/terraform/tooling_orchestrator/ecs.tf
+++ b/terraform/tooling_orchestrator/ecs.tf
@@ -5,16 +5,14 @@
 resource "aws_ecs_cluster" "tooling_orchestrators" {
   name = "tooling_orchestrators"
 }
-data "template_file" "tooling_orchestrators" {
-  template = file("./tooling_orchestrator/ecs_task_definition.json.tpl")
-
-  vars = {
+locals {
+  container_definition = templatefile("./tooling_orchestrator/ecs_task_definition.json.tpl", {
     application_image = "${aws_ecr_repository.application.repository_url}:latest"
     nginx_image       = "${aws_ecr_repository.nginx.repository_url}:latest"
     http_port         = var.http_port
     region            = var.region
     log_group_name    = aws_cloudwatch_log_group.tooling_orchestrators.name
-  }
+  })
 }
 resource "aws_ecs_task_definition" "tooling_orchestrators" {
   family                   = "tooling_orchestrators"
@@ -22,7 +20,7 @@ resource "aws_ecs_task_definition" "tooling_orchestrators" {
   network_mode             = "awsvpc"
   cpu                      = var.container_cpu
   memory                   = var.container_memory
-  container_definitions    = data.template_file.tooling_orchestrators.rendered
+  container_definitions    = local.container_definition
   execution_role_arn       = var.aws_iam_role_ecs_task_execution.arn
   task_role_arn            = aws_iam_role.ecs.arn
   tags                     = {}

--- a/terraform/webservers/ecs.tf
+++ b/terraform/webservers/ecs.tf
@@ -1,4 +1,4 @@
-# ###
+
 # Set up the cluster
 # ###
 resource "aws_ecs_cluster" "webservers" {

--- a/terraform/webservers/ecs_anycable.tf
+++ b/terraform/webservers/ecs_anycable.tf
@@ -1,10 +1,8 @@
 # ###
 # Set up the cluster
 # ###
-data "template_file" "anycable" {
-  template = file("./webservers/ecs_task_definition_anycable.json.tpl")
-
-  vars = {
+locals {
+  anycable_container_definitions = templatefile("./webservers/ecs_task_definition_anycable.json.tpl", {
     nginx_image        = "${aws_ecr_repository.nginx.repository_url}:latest"
     rails_image        = "${aws_ecr_repository.rails.repository_url}:latest"
     anycable_go_image  = "${var.aws_ecr_repository_anycable_go_pro.repository_url}:latest"
@@ -13,7 +11,7 @@ data "template_file" "anycable" {
     region             = var.region
     log_group_name     = aws_cloudwatch_log_group.webservers.name
     log_group_prefix     = "anycable"
-  }
+  })
 }
 resource "aws_ecs_task_definition" "anycable" {
   family                   = "anycable"
@@ -21,7 +19,7 @@ resource "aws_ecs_task_definition" "anycable" {
   network_mode             = "awsvpc"
   cpu                      = var.service_anycable_cpu
   memory                   = var.service_anycable_memory
-  container_definitions    = data.template_file.anycable.rendered
+  container_definitions    = local.anycable_container_definitions
   execution_role_arn       = var.aws_iam_role_ecs_task_execution.arn
   task_role_arn            = aws_iam_role.ecs.arn
   tags                     = {}

--- a/terraform/webservers/ecs_api.tf
+++ b/terraform/webservers/ecs_api.tf
@@ -1,10 +1,8 @@
 # ###
 # Set up the cluster
 # ###
-data "template_file" "api_puma" {
-  template = file("./webservers/ecs_task_definition_puma.json.tpl")
-
-  vars = {
+locals {
+  api_container_definitions = templatefile("./webservers/ecs_task_definition_puma.json.tpl", {
     nginx_image                  = "${aws_ecr_repository.nginx.repository_url}:latest"
     rails_image                  = "${aws_ecr_repository.rails.repository_url}:latest"
     http_port                    = var.http_port
@@ -14,7 +12,7 @@ data "template_file" "api_puma" {
     log_group_prefix     = "api"
     efs_submissions_mount_point  = var.efs_submissions_mount_point
     efs_repositories_mount_point = var.efs_repositories_mount_point
-  }
+  })
 }
 resource "aws_ecs_task_definition" "api" {
   family                   = "api"
@@ -22,7 +20,7 @@ resource "aws_ecs_task_definition" "api" {
   network_mode             = "awsvpc"
   cpu                      = var.service_api_cpu
   memory                   = var.service_api_memory
-  container_definitions    = data.template_file.api_puma.rendered
+  container_definitions    = local.api_container_definitions
   execution_role_arn       = var.aws_iam_role_ecs_task_execution.arn
   task_role_arn            = aws_iam_role.ecs.arn
   tags                     = {}

--- a/terraform/webservers/ecs_website.tf
+++ b/terraform/webservers/ecs_website.tf
@@ -1,10 +1,8 @@
 # ###
 # Set up the cluster
 # ###
-data "template_file" "website_puma" {
-  template = file("./webservers/ecs_task_definition_puma.json.tpl")
-
-  vars = {
+locals {
+  website_container_definitions = templatefile("./webservers/ecs_task_definition_puma.json.tpl", {
     nginx_image                  = "${aws_ecr_repository.nginx.repository_url}:latest"
     rails_image                  = "${aws_ecr_repository.rails.repository_url}:latest"
     http_port                    = var.http_port
@@ -14,7 +12,7 @@ data "template_file" "website_puma" {
     log_group_prefix               = "website"
     efs_submissions_mount_point  = var.efs_submissions_mount_point
     efs_repositories_mount_point = var.efs_repositories_mount_point
-  }
+  })
 }
 resource "aws_ecs_task_definition" "website" {
   family                   = "website"
@@ -22,7 +20,7 @@ resource "aws_ecs_task_definition" "website" {
   network_mode             = "awsvpc"
   cpu                      = var.service_website_cpu
   memory                   = var.service_website_memory
-  container_definitions    = data.template_file.website_puma.rendered
+  container_definitions    = local.website_container_definitions
   execution_role_arn       = var.aws_iam_role_ecs_task_execution.arn
   task_role_arn            = aws_iam_role.ecs.arn
   tags                     = {}


### PR DESCRIPTION
Adds support for a canary script which runs every 30s. Also gives permission to the `exercism` user to shut down the machine.

In the long run, this would be better as a http endpoint that could be hit and monitored by EC2.

Goes with https://github.com/exercism/tooling-invoker/pull/63